### PR TITLE
step15, 16: 트랜잭션 범위 축소, 서비스 분리 

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,8 +29,9 @@ dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-web'
     implementation 'org.springframework.boot:spring-boot-starter-data-redis'
     implementation 'com.fasterxml.jackson.datatype:jackson-datatype-jsr310'
+
     compileOnly 'org.projectlombok:lombok'
-    runtimeOnly 'com.h2database:h2'
+    runtimeOnly 'com.mysql:mysql-connector-j'
     annotationProcessor 'org.projectlombok:lombok'
     testImplementation 'org.springframework.boot:spring-boot-starter-test'
     testRuntimeOnly 'org.junit.platform:junit-platform-launcher'

--- a/docs/시퀀스 다이어그램.md
+++ b/docs/시퀀스 다이어그램.md
@@ -1,26 +1,53 @@
 # 시퀀스다이어그램
 
-## 1. 대기 서비스
+## 1. 대기열 서비스
+
+### 1-1. 대기열 진입
 
 ```mermaid
 sequenceDiagram
-    autonumber
-    participant CLIENT
+    actor CLIENT
     participant API
-    participant USER_SERVICE
     participant QUEUE_SERVICE
-    CLIENT ->> API: 접속 대기 요청
-    API ->> USER_SERVICE: 회원 조회
-    USER_SERVICE -->> API: 회원 반환
-    API ->> QUEUE_SERVICE: 대기 코드 요청
-    QUEUE_SERVICE ->> QUEUE_SERVICE: 대기 코드 생성 및 저장
-    QUEUE_SERVICE -->> API: 대기 코드 반환
-    API -->> CLIENT: 접속 대기 성공(대기 코드)
-    CLIENT ->> API: 접속 대기 상태 조회
-    API ->> QUEUE_SERVICE: 접속 대기 상태 조회
-    QUEUE_SERVICE ->> API: 접속 대기 상태 반환
-    API ->> CLIENT: 접속 대기 상태(대기 상태, 대기 번호 등) 반환
+    participant REDIS
+%% Step 1: 대기열 진입 
+    CLIENT ->> API: 진입 요청
+    API ->> + QUEUE_SERVICE: 토큰 요청
+    note over QUEUE_SERVICE: 토큰 생성
+    QUEUE_SERVICE ->> REDIS: 활성화 토큰 수 조회
+    REDIS ->> QUEUE_SERVICE: 활성화 토큰 수 반환
+    alt 활성 토큰 수 < 임계값
+        QUEUE_SERVICE ->> REDIS: 활성화열 토큰 저장
+    else
+        QUEUE_SERVICE ->> REDIS: 대기열 토큰 저장
+    end
+    QUEUE_SERVICE -->> - API: 토큰 반환
+    API -->> CLIENT: 토큰 응답
+```
 
+### 1-2. 토큰 상태 확인
+
+```mermaid
+sequenceDiagram
+    actor CLIENT
+    participant API
+    participant QUEUE_SERVICE
+    participant REDIS
+%% Step 2: 토큰 상태 확인  
+    loop 10초 마다
+        CLIENT ->> API: 토큰 상태 요청
+        API ->> + QUEUE_SERVICE: 토큰 상태 조회
+        QUEUE_SERVICE ->> REDIS: 대기열 토큰 위치 조회
+        REDIS ->> QUEUE_SERVICE: 대기열 토큰 위치 반환
+        alt 토큰 위치 > 0
+            QUEUE_SERVICE ->> API: 토큰 상태 반환
+        else
+            QUEUE_SERVICE ->> REDIS: 활성화열 토큰 조회
+            REDIS ->> QUEUE_SERVICE: 활성화열 토큰 반환
+            QUEUE_SERVICE -->> - API: 토큰 상태 반환
+        end
+        API -->> CLIENT: 토큰 상태 응답
+    end 
 ```
 
 ## 2. 콘서트 서비스
@@ -52,13 +79,10 @@ sequenceDiagram
     autonumber
     participant CLIENT
     participant API
-    participant QUEUE_SERVICE
     participant USER_SERVICE
     participant CONCERT_SERVICE
     participant RESERVATION_SERVICE
     CLIENT ->> API: 공연 좌석 예약 요청
-    API ->> QUEUE_SERVICE: 대기 상태 조회
-    QUEUE_SERVICE -->> API: 활성화 상태 중 (성공)
     API ->> USER_SERVICE: 회원 조회
     USER_SERVICE -->> API: 회원 반환
     API ->> CONCERT_SERVICE: 공연 좌석 상태 조회
@@ -72,9 +96,7 @@ sequenceDiagram
     alt 좌석 이미 예약된 경우
         CONCERT_SERVICE -->> API: 이미 예약된 좌석 (실패)
         API -->> CLIENT: 예약 실패 응답 (좌석 이미 예약됨)
-    else 대기중, 대기 만료 상태 만료 시
-        QUEUE_SERVICE -->> API: 대기중, 대기 만료 (실패)
-        API -->> CLIENT: 결제 실패 응답
+    else
     end
 
 
@@ -85,35 +107,31 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     autonumber
-    participant CLIENT
+    actor CLIENT
     participant API
-    participant QUEUE_SERVICE
     participant USER_SERVICE
-    participant ACCOUNT_SERVICE
-    participant RESERVATION_SERVICE
-    participant PAYMENT_SERVICE
-    CLIENT ->> API: 예약 결제 요청
-    API ->> QUEUE_SERVICE: 대기 상태 조회
-    QUEUE_SERVICE -->> API: 활성화 상태 중 (성공)
+    box rgb(33,66,99) transaction
+        participant RESERVATION_SERVICE
+        participant ACCOUNT_SERVICE
+        participant PAYMENT_SERVICE
+    end
+    CLIENT ->> API: 결제 요청
     API ->> USER_SERVICE: 회원 조회
     USER_SERVICE -->> API: 회원 반환
+    API ->> RESERVATION_SERVICE: 예약 내역 조회
+    note over RESERVATION_SERVICE: 예약 상태('결제완료') 변경
+    RESERVATION_SERVICE -->> API: 예약 내역 반환
     API ->> ACCOUNT_SERVICE: 계좌 잔액 조회
-    ACCOUNT_SERVICE -->> API: 계좌 잔액 충분 (성공)
-    API ->> RESERVATION_SERVICE: 예약 가능 여부 확인
-    RESERVATION_SERVICE -->> API: 예약 가능 (성공)
-    API ->> PAYMENT_SERVICE: 결제 요청
-    PAYMENT_SERVICE -->> API: 결제 성공
-    API -->> CLIENT: 결제 성공 응답
-
-    alt 잔액 부족 또는 대기 상태 만료 시
-        ACCOUNT_SERVICE -->> API: 계좌 잔액 부족 (실패)
+    alt 잔액 부족 시
+        ACCOUNT_SERVICE -->> API: 계좌 잔액 부족(실패)
         API -->> CLIENT: 결제 실패 응답 (잔액 부족)
-    else 대기중, 대기 만료 상태 만료 시
-        QUEUE_SERVICE -->> API: 대기중, 대기 만료 (실패)
-        API -->> CLIENT: 결제 실패 응답
+    else
+        note over ACCOUNT_SERVICE: 계좌 잔액 차감
     end
-
-
+    API -->> PAYMENT_SERVICE: 결제 내역 생성
+    note over PAYMENT_SERVICE: 결제 내역 생성
+    PAYMENT_SERVICE -->> API: 결제 내역 반환
+    API -->> CLIENT: 결제 응답
 ```
 
 ## 5. 계좌 서비스

--- a/docs/시퀀스 다이어그램.md
+++ b/docs/시퀀스 다이어그램.md
@@ -77,28 +77,31 @@ sequenceDiagram
 ```mermaid
 sequenceDiagram
     autonumber
-    participant CLIENT
+    actor CLIENT
     participant API
+    participant EVENT_SYSTEM
     participant USER_SERVICE
     participant CONCERT_SERVICE
     participant RESERVATION_SERVICE
-    CLIENT ->> API: 공연 좌석 예약 요청
+    CLIENT ->> API: 좌석 예약 요청
     API ->> USER_SERVICE: 회원 조회
     USER_SERVICE -->> API: 회원 반환
-    API ->> CONCERT_SERVICE: 공연 좌석 상태 조회
-    CONCERT_SERVICE -->> API: 좌석 예약 가능 (성공)
-    CONCERT_SERVICE ->> CONCERT_SERVICE: 좌석 상태(예약) 변경
-    CONCERT_SERVICE -->> API: 좌석 상태 변경 성공
-    API ->> RESERVATION_SERVICE: 예약 정보 저장
-    RESERVATION_SERVICE -->> API: 예약 저장 성공
-    API -->> CLIENT: 예약 성공 응답
-
-    alt 좌석 이미 예약된 경우
+    API ->> CONCERT_SERVICE: 좌석 조회
+    alt 좌석이 이미 예약된 경우
         CONCERT_SERVICE -->> API: 이미 예약된 좌석 (실패)
         API -->> CLIENT: 예약 실패 응답 (좌석 이미 예약됨)
     else
+        note over CONCERT_SERVICE: 좌석 상태('예약됨')변경
+        note over CONCERT_SERVICE: 좌석 예약 이벤트 발행
+        CONCERT_SERVICE -->> API: 예약 성공 응답
     end
-
+    EVENT_SYSTEM ->> RESERVATION_SERVICE: 예약 정보 저장
+    note over RESERVATION_SERVICE: 예약 정보 생성
+    RESERVATION_SERVICE -->> API: 예약 정보 반환
+    alt 예약 정보 저장 실패 시
+        RESERVATION_SERVICE -->> CONCERT_SERVICE: 좌석 상태('예약가능') 변경
+    end
+    API -->> CLIENT: 예약 성공 응답
 
 ```
 

--- a/src/main/java/com/hhplus/concert/ConcertBookingServiceApplication.java
+++ b/src/main/java/com/hhplus/concert/ConcertBookingServiceApplication.java
@@ -4,8 +4,10 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.cache.annotation.EnableCaching;
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.annotation.EnableScheduling;
 
+@EnableAsync
 @EnableCaching
 @EnableJpaAuditing
 @EnableScheduling

--- a/src/main/java/com/hhplus/concert/application/PaymentFacade.java
+++ b/src/main/java/com/hhplus/concert/application/PaymentFacade.java
@@ -9,12 +9,13 @@ import com.hhplus.concert.domain.user.User;
 import com.hhplus.concert.domain.user.UserService;
 import lombok.AllArgsConstructor;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Service
 @AllArgsConstructor
 public class PaymentFacade {
 
+    private final TransactionTemplate transactionTemplate;
     private final UserService userService;
     private final AccountService accountService;
     private final ReservationService reservationService;
@@ -23,14 +24,20 @@ public class PaymentFacade {
     /**
      * 콘서트 예약 결제
      */
-    @Transactional
     public PaymentInfo pay(Long userId, Long reservationId) {
+        // 1. 회원을 조회한다.
         User user = userService.getUser(userId);
 
-        Reservation reservation = reservationService.getReservation(reservationId);
-        reservation.complete();
+        // start transaction()
+        return transactionTemplate.execute(status -> {
+            // 2. 예약 상태를 '결제완료' 상태로 변경한다.
+            Reservation reservation = reservationService.completeReservation(reservationId);
 
-        accountService.use(user, reservation.getAmount());
-        return paymentService.pay(reservation);
+            // 3. 잔고 금액을 차감한다.
+            accountService.use(user, reservation.getAmount());
+
+            // 4. 결제 내역을 생성한다.
+            return paymentService.pay(reservation);
+        });
     }
 }

--- a/src/main/java/com/hhplus/concert/application/ReservationFacade.java
+++ b/src/main/java/com/hhplus/concert/application/ReservationFacade.java
@@ -1,5 +1,6 @@
 package com.hhplus.concert.application;
 
+import com.hhplus.concert.application.event.ReservedEvent;
 import com.hhplus.concert.domain.concert.ConcertService;
 import com.hhplus.concert.domain.concert.Seat;
 import com.hhplus.concert.domain.reservation.Reservation;
@@ -10,8 +11,9 @@ import com.hhplus.concert.domain.user.User;
 import com.hhplus.concert.domain.user.UserService;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
-import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.support.TransactionTemplate;
 
 @Slf4j
 @Service
@@ -21,15 +23,23 @@ public class ReservationFacade {
     private final UserService userService;
     private final ConcertService concertService;
     private final ReservationService reservationService;
+    private final ApplicationEventPublisher eventPublisher;
+    private final TransactionTemplate transactionTemplate;
 
     /**
      * 좌석 예약
      */
-    @Transactional
     public ReservationInfo placeReservation(ReservationCommand command) {
+        // 1. 회원을 조회한다.
         User user = userService.getUser(command.getUserId());
-        Seat seat = concertService.occupySeat(command.getConcertId(), command.getPerformanceId(), command.getSeatId());
-        Reservation reserve = reservationService.placeReservation(user, seat);
-        return ReservationInfo.toReservationInfo(reserve);
+        // 2. '예약가능'한 상태의 좌석을 조회한다.
+        Seat seat = concertService.getAvailableSeat(command.getConcertId(), command.getPerformanceId(), command.getSeatId());
+
+        // 3. 예약 내역을 생성 및 예약 생성 이벤트를 발행한다.
+        return transactionTemplate.execute(status -> {
+            Reservation reservation = reservationService.placeReservation(user, seat);
+            eventPublisher.publishEvent(new ReservedEvent(reservation.getId(), command.getSeatId()));
+            return ReservationInfo.from(reservation);
+        });
     }
 }

--- a/src/main/java/com/hhplus/concert/application/event/ReservedEvent.java
+++ b/src/main/java/com/hhplus/concert/application/event/ReservedEvent.java
@@ -1,0 +1,11 @@
+package com.hhplus.concert.application.event;
+
+import lombok.AllArgsConstructor;
+import lombok.Data;
+
+@Data
+@AllArgsConstructor
+public class ReservedEvent {
+    private Long reservationId;
+    private Long seatId;
+}

--- a/src/main/java/com/hhplus/concert/domain/account/Account.java
+++ b/src/main/java/com/hhplus/concert/domain/account/Account.java
@@ -7,14 +7,14 @@ import com.hhplus.concert.domain.user.User;
 import jakarta.persistence.*;
 import lombok.Getter;
 
-import static jakarta.persistence.GenerationType.AUTO;
+import static jakarta.persistence.GenerationType.IDENTITY;
 
 @Getter
 @Entity
 @Table(name = "account")
 public class Account extends BaseTimeEntity {
     @Id
-    @GeneratedValue(strategy = AUTO)
+    @GeneratedValue(strategy = IDENTITY)
     @Column(name = "account_id")
     private Long id;
 

--- a/src/main/java/com/hhplus/concert/domain/concert/Concert.java
+++ b/src/main/java/com/hhplus/concert/domain/concert/Concert.java
@@ -21,7 +21,7 @@ import static jakarta.persistence.GenerationType.*;
 @AllArgsConstructor
 public class Concert extends BaseTimeEntity {
     @Id
-    @GeneratedValue(strategy = AUTO)
+    @GeneratedValue(strategy = IDENTITY)
     @Column(name = "concert_id")
     private Long id;
 

--- a/src/main/java/com/hhplus/concert/domain/concert/ConcertPerformance.java
+++ b/src/main/java/com/hhplus/concert/domain/concert/ConcertPerformance.java
@@ -26,7 +26,7 @@ import static jakarta.persistence.GenerationType.*;
 public class ConcertPerformance extends BaseTimeEntity {
     @Id
     @Column(name = "concert_performance_id")
-    @GeneratedValue(strategy = AUTO)
+    @GeneratedValue(strategy = IDENTITY)
     private Long id;
 
     @Description("공연일")

--- a/src/main/java/com/hhplus/concert/domain/concert/ConcertRepository.java
+++ b/src/main/java/com/hhplus/concert/domain/concert/ConcertRepository.java
@@ -9,5 +9,7 @@ public interface ConcertRepository {
 
     ConcertPerformance getPerformance(Long concertId, Long performanceId);
 
+    Seat getSeat(Long seatId);
+
     Seat getSeatForUpdate(Long seatId);
 }

--- a/src/main/java/com/hhplus/concert/domain/concert/Seat.java
+++ b/src/main/java/com/hhplus/concert/domain/concert/Seat.java
@@ -19,7 +19,7 @@ import static jakarta.persistence.GenerationType.*;
 @Table(name = "seat")
 public class Seat {
     @Id
-    @GeneratedValue(strategy = AUTO)
+    @GeneratedValue(strategy = IDENTITY)
     @Column(name = "seat_id")
     private Long id;
 

--- a/src/main/java/com/hhplus/concert/domain/payment/Payment.java
+++ b/src/main/java/com/hhplus/concert/domain/payment/Payment.java
@@ -13,7 +13,7 @@ import static jakarta.persistence.GenerationType.*;
 @Table(name = "payment")
 public class Payment extends BaseTimeEntity {
     @Id
-    @GeneratedValue(strategy = AUTO)
+    @GeneratedValue(strategy = IDENTITY)
     @Column(name = "payment_id")
     private Long id;
 

--- a/src/main/java/com/hhplus/concert/domain/reservation/Reservation.java
+++ b/src/main/java/com/hhplus/concert/domain/reservation/Reservation.java
@@ -19,7 +19,7 @@ import static jakarta.persistence.GenerationType.*;
 @AllArgsConstructor
 public class Reservation extends BaseTimeEntity {
     @Id
-    @GeneratedValue(strategy = AUTO)
+    @GeneratedValue(strategy = IDENTITY)
     @Column(name = "reservation_id")
     private Long id;
 

--- a/src/main/java/com/hhplus/concert/domain/reservation/Reservation.java
+++ b/src/main/java/com/hhplus/concert/domain/reservation/Reservation.java
@@ -3,6 +3,8 @@ package com.hhplus.concert.domain.reservation;
 import com.hhplus.concert.domain.BaseTimeEntity;
 
 import com.hhplus.concert.domain.concert.Seat;
+import com.hhplus.concert.domain.support.error.CoreException;
+import com.hhplus.concert.domain.support.error.ErrorType;
 import com.hhplus.concert.domain.user.User;
 import jakarta.persistence.*;
 import jdk.jfr.Description;
@@ -58,6 +60,13 @@ public class Reservation extends BaseTimeEntity {
 
     public void complete() {
         this.status = ReservationStatus.PAYMENT_COMPLETED;
+    }
+
+    public void fail() {
+        if (this.status.equals(ReservationStatus.PAYMENT_COMPLETED)) {
+            throw new CoreException(ErrorType.RESERVATION_ALREADY_PAID, this.id);
+        }
+        this.status = ReservationStatus.FAIL;
     }
 }
 

--- a/src/main/java/com/hhplus/concert/domain/reservation/ReservationCommand.java
+++ b/src/main/java/com/hhplus/concert/domain/reservation/ReservationCommand.java
@@ -10,7 +10,7 @@ public class ReservationCommand {
     private Long performanceId;
     private Long seatId;
 
-    public static ReservationCommand toReservationCommand(ReservationDto.ReservationRequest request) {
+    public static ReservationCommand of(ReservationDto.ReservationRequest request) {
         ReservationCommand command = new ReservationCommand();
         command.setUserId(request.getUserId());
         command.setConcertId(request.getConcertId());

--- a/src/main/java/com/hhplus/concert/domain/reservation/ReservationInfo.java
+++ b/src/main/java/com/hhplus/concert/domain/reservation/ReservationInfo.java
@@ -8,7 +8,7 @@ public class ReservationInfo {
     private String status;
     private Integer amount;
 
-    public static ReservationInfo toReservationInfo(Reservation reservation) {
+    public static ReservationInfo from(Reservation reservation) {
         ReservationInfo info = new ReservationInfo();
         info.setId(reservation.getId());
         info.setStatus(reservation.getStatus().toString());

--- a/src/main/java/com/hhplus/concert/domain/reservation/ReservationService.java
+++ b/src/main/java/com/hhplus/concert/domain/reservation/ReservationService.java
@@ -36,6 +36,16 @@ public class ReservationService {
     }
 
     /**
+     * 좌석 예약
+     */
+    @Transactional
+    public Reservation completeReservation(Long reservationId) {
+        Reservation reservation = getReservation(reservationId);
+        reservation.complete();
+        return reservation;
+    }
+
+    /**
      * 일정 시간까지 결제되지 않은 좌석은 예약 가능한 상태로 변경한다.
      */
     @Transactional

--- a/src/main/java/com/hhplus/concert/domain/reservation/ReservationService.java
+++ b/src/main/java/com/hhplus/concert/domain/reservation/ReservationService.java
@@ -46,6 +46,16 @@ public class ReservationService {
     }
 
     /**
+     * 좌석 예약
+     */
+    @Transactional
+    public Reservation failReservation(Long reservationId) {
+        Reservation reservation = getReservation(reservationId);
+        reservation.fail();
+        return reservation;
+    }
+
+    /**
      * 일정 시간까지 결제되지 않은 좌석은 예약 가능한 상태로 변경한다.
      */
     @Transactional

--- a/src/main/java/com/hhplus/concert/domain/reservation/ReservationStatus.java
+++ b/src/main/java/com/hhplus/concert/domain/reservation/ReservationStatus.java
@@ -1,5 +1,5 @@
 package com.hhplus.concert.domain.reservation;
 
 public enum ReservationStatus {
-    PAYMENT_WAITING, PAYMENT_COMPLETED, PAYMENT_EXPIRED, CANCELED
+    PAYMENT_WAITING, PAYMENT_COMPLETED, PAYMENT_EXPIRED, CANCELED, FAIL
 }

--- a/src/main/java/com/hhplus/concert/domain/support/error/ErrorType.java
+++ b/src/main/java/com/hhplus/concert/domain/support/error/ErrorType.java
@@ -23,6 +23,7 @@ public enum ErrorType {
     MINIMUM_CHARGE_AMOUNT(ErrorCode.BUSINESS_ERROR, "1,000원 이상 충전이 가능합니다.", LogLevel.INFO),
     NOT_ENOUGH_ACCOUNT_AMOUNT(ErrorCode.BUSINESS_ERROR, "계좌 잔액이 부족합니다.", LogLevel.INFO),
     NOT_ACTIVE_QUEUE(ErrorCode.BUSINESS_ERROR, "아직 대기 상태입니다.", LogLevel.INFO),
+    RESERVATION_ALREADY_PAID(ErrorCode.BUSINESS_ERROR, "이미 결제 완료된 예약입니다.", LogLevel.WARN),
 
     // server error
     FAIL_SAVE_QUEUE(ErrorCode.SERVER_ERROR, "대기열 등록에 실패했습니다.", LogLevel.WARN);

--- a/src/main/java/com/hhplus/concert/domain/user/User.java
+++ b/src/main/java/com/hhplus/concert/domain/user/User.java
@@ -16,7 +16,7 @@ import static jakarta.persistence.GenerationType.*;
 @AllArgsConstructor
 public class User {
     @Id
-    @GeneratedValue(strategy = AUTO)
+    @GeneratedValue(strategy = IDENTITY)
     @Column(name = "user_id")
     private Long id;
 

--- a/src/main/java/com/hhplus/concert/infra/concert/ConcertJpaRepository.java
+++ b/src/main/java/com/hhplus/concert/infra/concert/ConcertJpaRepository.java
@@ -24,4 +24,7 @@ public interface ConcertJpaRepository extends CrudRepository<Concert, Long> {
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query("SELECT s FROM Seat s WHERE s.id = :seatId")
     Optional<Seat> findSeatForUpdate(@Param("seatId") Long seatId);
+
+    @Query("SELECT s FROM Seat s WHERE s.id = :seatId")
+    Optional<Seat> findSeat(Long seatId);
 }

--- a/src/main/java/com/hhplus/concert/infra/concert/ConcertRepositoryImpl.java
+++ b/src/main/java/com/hhplus/concert/infra/concert/ConcertRepositoryImpl.java
@@ -33,6 +33,11 @@ public class ConcertRepositoryImpl implements ConcertRepository {
     }
 
     @Override
+    public Seat getSeat(Long seatId) {
+        return concertJpaRepository.findSeat(seatId).orElse(null);
+    }
+
+    @Override
     public Seat getSeatForUpdate(Long seatId) {
         return concertJpaRepository.findSeatForUpdate(seatId).orElse(null);
     }

--- a/src/main/java/com/hhplus/concert/interfaces/reservation/ReservationController.java
+++ b/src/main/java/com/hhplus/concert/interfaces/reservation/ReservationController.java
@@ -23,7 +23,7 @@ public class ReservationController {
     public ResponseEntity<ReservationDto.ReservationResponse> reserve(
             @RequestBody ReservationDto.ReservationRequest request
     ) {
-        ReservationInfo info = reservationFacade.placeReservation(ReservationCommand.toReservationCommand(request));
+        ReservationInfo info = reservationFacade.placeReservation(ReservationCommand.of(request));
         ReservationDto.ReservationResponse result = ReservationDto.ReservationResponse.builder()
                 .id(info.getId())
                 .status(info.getStatus())

--- a/src/main/java/com/hhplus/concert/interfaces/reservation/ReservationEventListener.java
+++ b/src/main/java/com/hhplus/concert/interfaces/reservation/ReservationEventListener.java
@@ -1,0 +1,34 @@
+package com.hhplus.concert.interfaces.reservation;
+
+import com.hhplus.concert.application.event.ReservedEvent;
+import com.hhplus.concert.domain.concert.ConcertService;
+import com.hhplus.concert.domain.reservation.ReservationService;
+import lombok.AllArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Propagation;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import static org.springframework.transaction.event.TransactionPhase.*;
+
+@Slf4j
+@Component
+@AllArgsConstructor
+public class ReservationEventListener {
+
+    private final ConcertService concertService;
+    private final ReservationService reservationService;
+
+    @Async
+    @TransactionalEventListener(phase = AFTER_COMMIT)
+    public void reserved(ReservedEvent event) {
+        log.info("event published 1");
+        try {
+            concertService.occupySeat(event.getSeatId());
+        } catch (Exception e) {
+            reservationService.failReservation(event.getReservationId());
+        }
+    }
+}

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,26 +1,19 @@
 spring:
   application:
     name: concert-system
-
   datasource:
-    driver-class-name: org.h2.Driver
-    #    url: jdbc:h2:mem:concert
-    url: jdbc:h2:tcp://localhost/~/workspace/h2/test
-    username: sa
-    password:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: jdbc:mysql://localhost:3306/concert
+    username: hhplus
+    password: 1111
   jpa:
-
     hibernate:
       ddl-auto: create-drop
     properties:
       hibernate:
         show_sql: ture
         format_sql: true
-
+        dialect: org.hibernate.dialect.MySQL8Dialect
 logging:
   level:
     org.hibernate.SQL: debug

--- a/src/test/java/com/hhplus/concert/application/PaymentFacadeTest.java
+++ b/src/test/java/com/hhplus/concert/application/PaymentFacadeTest.java
@@ -47,37 +47,36 @@ class PaymentFacadeTest {
     @Autowired
     ReservationJpaRepository reservationJpaRepository;
 
-    User user;
-    Seat seat1;
-    Seat seat2;
-    Seat seat3;
-    ConcertPerformance performance;
-    Concert concert;
+    User USER;
+    Account ACCOUNT;
+    Concert CONCERT;
+    ConcertPerformance PERFORMANCE;
+    Seat SEAT1, SEAT2;
 
     @BeforeEach
     void init() {
-        user = new User("username", "email");
-        userJpaRepository.save(user);
-        accountJpaRepository.save(new Account(150000L, user));
+        USER = new User("username", "email");
+        userJpaRepository.save(USER);
 
-        seat1 = new Seat("BASIC", 1, 100000, SeatStatus.AVAILABLE);
-        seat2 = new Seat("VIP", 2, 150000, SeatStatus.RESERVED);
-        seat3 = new Seat("VIP", 3, 250000, SeatStatus.RESERVED);
+        ACCOUNT = new Account(100000L, USER);
+        accountJpaRepository.save(ACCOUNT);
 
-        performance = new ConcertPerformance(LocalDate.now(), LocalDateTime.now().plusMinutes(100), LocalDateTime.now().plusMinutes(250), List.of(seat1, seat2));
-        concert = new Concert("concert", List.of(performance));
-        concertJpaRepository.save(concert);
+        SEAT1 = new Seat("BASIC", 1, 100000, SeatStatus.AVAILABLE);
+        SEAT2 = new Seat("VIP", 2, 150000, SeatStatus.RESERVED);
+        PERFORMANCE = new ConcertPerformance(LocalDate.now(), LocalDateTime.now().plusMinutes(30), LocalDateTime.now().plusMinutes(250), List.of(SEAT1, SEAT2));
+        CONCERT = new Concert("concert", List.of(PERFORMANCE));
+        concertJpaRepository.save(CONCERT);
     }
 
     @DisplayName("예약건이 존재하는 경우 해당 예약에 대한 결제가 가능하다.")
     @Test
     void 예약_결제() {
         // given
-        Reservation reservation = new Reservation(ReservationStatus.PAYMENT_WAITING, seat2.getPrice(), user, seat2);
+        Reservation reservation = new Reservation(ReservationStatus.PAYMENT_WAITING, SEAT1.getPrice(), USER, SEAT1);
         reservationJpaRepository.save(reservation);
 
         // when
-        PaymentInfo payment = paymentFacade.pay(user.getId(), reservation.getId());
+        PaymentInfo payment = paymentFacade.pay(USER.getId(), reservation.getId());
         assertThat(payment).isNotNull();
     }
 
@@ -85,12 +84,12 @@ class PaymentFacadeTest {
     @Test
     void 잔액_부족_예약_결제() {
         // given
-        Reservation reservation = new Reservation(ReservationStatus.PAYMENT_WAITING, seat3.getPrice(), user, seat2);
+        Reservation reservation = new Reservation(ReservationStatus.PAYMENT_WAITING, SEAT2.getPrice(), USER, SEAT2);
         reservationJpaRepository.save(reservation);
 
         // when, then
         CoreException exception = Assertions.assertThrows(CoreException.class,
-                () -> paymentFacade.pay(user.getId(), reservation.getId()));
+                () -> paymentFacade.pay(USER.getId(), reservation.getId()));
         assertThat(exception.getErrorType()).isEqualTo(ErrorType.NOT_ENOUGH_ACCOUNT_AMOUNT);
     }
 }

--- a/src/test/java/com/hhplus/concert/application/ReservationFacadeTest.java
+++ b/src/test/java/com/hhplus/concert/application/ReservationFacadeTest.java
@@ -18,7 +18,6 @@ import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.annotation.Rollback;
 
 import java.time.LocalDate;
 import java.time.LocalDateTime;
@@ -26,10 +25,8 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.*;
 
-@Rollback(value = false)
 @SpringBootTest
 class ReservationFacadeTest {
-
     @Autowired
     ReservationFacade reservationFacade;
 
@@ -39,35 +36,26 @@ class ReservationFacadeTest {
     @Autowired
     ConcertJpaRepository concertJpaRepository;
 
-    User user;
-    Seat seat1, seat2, seat3, seat4;
-    ConcertPerformance performance1, performance2;
-    Concert concert;
+    User USER;
+    Concert CONCERT;
+    ConcertPerformance PERFORMANCE1, PERFORMANCE2;
+    Seat SEAT1, SEAT2, SEAT3, SEAT4;
 
     @BeforeEach
     void init() {
-        user = new User("username", "email");
-        userJpaRepository.save(user);
+        USER = new User("username", "email");
+        userJpaRepository.save(USER);
 
-        seat1 = new Seat("BASIC", 1, 100000, SeatStatus.AVAILABLE);
-        seat2 = new Seat("VIP", 2, 150000, SeatStatus.RESERVED);
-        seat3 = new Seat("BASIC", 1, 100000, SeatStatus.AVAILABLE);
-        seat4 = new Seat("VIP", 2, 150000, SeatStatus.RESERVED);
+        SEAT1 = new Seat("BASIC", 1, 100000, SeatStatus.AVAILABLE);
+        SEAT2 = new Seat("VIP", 2, 150000, SeatStatus.RESERVED);
+        SEAT3 = new Seat("BASIC", 1, 100000, SeatStatus.AVAILABLE);
+        SEAT4 = new Seat("VIP", 2, 150000, SeatStatus.RESERVED);
 
-        performance1 = new ConcertPerformance(
-                LocalDate.now(),
-                LocalDateTime.now().plusMinutes(30),
-                LocalDateTime.now().plusMinutes(250),
-                List.of(seat1, seat2)
-        );
-        performance2 = new ConcertPerformance(
-                LocalDate.now(),
-                LocalDateTime.now().plusMinutes(100),
-                LocalDateTime.now().plusMinutes(250),
-                List.of(seat3, seat4)
-        );
-        concert = new Concert("concert", List.of(performance1, performance2));
-        concertJpaRepository.save(concert);
+        LocalDate now = LocalDate.now();
+        PERFORMANCE1 = new ConcertPerformance(now, LocalDateTime.now().plusMinutes(30), LocalDateTime.now().plusMinutes(250), List.of(SEAT1, SEAT2));
+        PERFORMANCE2 = new ConcertPerformance(now, LocalDateTime.now().plusMinutes(100), LocalDateTime.now().plusMinutes(250), List.of(SEAT3, SEAT4));
+        CONCERT = new Concert("concert", List.of(PERFORMANCE1, PERFORMANCE2));
+        concertJpaRepository.save(CONCERT);
     }
 
     @DisplayName("공연 시작 시간 30분 이후 공연은 예약 불가능하다.")
@@ -75,25 +63,25 @@ class ReservationFacadeTest {
     void 예약_불가능_공연_예약() {
         // given
         ReservationCommand command = new ReservationCommand();
-        command.setUserId(user.getId());
-        command.setConcertId(concert.getId());
-        command.setPerformanceId(performance1.getId());
-        command.setSeatId(seat2.getId());
+        command.setUserId(USER.getId());
+        command.setConcertId(CONCERT.getId());
+        command.setPerformanceId(PERFORMANCE1.getId());
+        command.setSeatId(SEAT2.getId());
 
         // when, then
         CoreException exception = Assertions.assertThrows(CoreException.class, () -> reservationFacade.placeReservation(command));
         assertThat(exception.getErrorType()).isEqualTo(ErrorType.PERFORMANCE_EXPIRED);
     }
 
-    @DisplayName("예약 가능한 상태의 좌석은 예약 가능하다.")
+    @DisplayName("예약 가능한 상태의 좌석은 예약 doInTransaction가능하다.")
     @Test
     void 예약_가능_좌석_예약() {
         // given
         ReservationCommand command = new ReservationCommand();
-        command.setUserId(user.getId());
-        command.setConcertId(concert.getId());
-        command.setPerformanceId(performance2.getId());
-        command.setSeatId(seat3.getId());
+        command.setUserId(USER.getId());
+        command.setConcertId(CONCERT.getId());
+        command.setPerformanceId(PERFORMANCE2.getId());
+        command.setSeatId(SEAT3.getId());
 
         // when
         ReservationInfo reserve = reservationFacade.placeReservation(command);
@@ -107,10 +95,10 @@ class ReservationFacadeTest {
     void 예약_불가능_좌석_예약() {
         // given
         ReservationCommand command = new ReservationCommand();
-        command.setUserId(user.getId());
-        command.setConcertId(concert.getId());
-        command.setPerformanceId(performance2.getId());
-        command.setSeatId(seat4.getId());
+        command.setUserId(USER.getId());
+        command.setConcertId(CONCERT.getId());
+        command.setPerformanceId(PERFORMANCE2.getId());
+        command.setSeatId(SEAT4.getId());
 
         // when, then
         CoreException exception = Assertions.assertThrows(CoreException.class, () -> reservationFacade.placeReservation(command));


### PR DESCRIPTION
# 작업 내용 

1. 결제 서비스에 transaction template을 적용하여 트랜잭션 범위를 축소하였습니다.
2. 좌석 예약 서비스에 이벤트 드리븐 아키텍처 + 보상 트랜잭션을 적용하여 트랜잭션 범위를 축소하였습니다. 

real mysql 8.0 난이도 문제로 인덱스에 대한 비교 분석은 하지 못했습니다. 죄송합니다. 😓

# 예약 동시성 테스트

1. facade 레이어 트랜잭션 설정 
 소요시간: 827ms

2. 이벤트 드리븐 아키텍처 설정 
소요시간: 753ms
